### PR TITLE
Fix schema project alias

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1,5 +1,5 @@
 {
-  "pluginAlias": "homebridge-mi-led-desk-lamp",
+  "pluginAlias": "mi-led-desk-lamp",
   "pluginType": "accessory",
   "singular": true,
   "footerDisplay": "Links might be helpful:\n\n[Obtain Mi Home device token](https://github.com/jghaanstra/com.xiaomi-miio/blob/master/docs/obtain_token.md)\n\n[Get Device Token Without Resetting on Non-Jailbroken iOS Devices](https://github.com/mediter/miio/blob/master/docs/ios-token-without-reset.md)",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,9 @@
 {
   "name": "homebridge-mi-led-desk-lamp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "main": "index.js",
-  "keywords": [
-    "homebridge-plugin"
-  ],
+  "keywords": ["homebridge-plugin"],
   "author": "",
   "license": "ISC",
   "engines": {


### PR DESCRIPTION
Sorry that in the last PR, schema's projectAlias was not properly set. An error would show up after fresh install & reboot.

```
No plugin was found for the accessory "homebridge-mi-led-desk-lamp" in your config.json. Please make sure the corresponding plugin is installed correctly.
```

This PR addresses that.
